### PR TITLE
Update javax.persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 		<xmlunit.version>1.3</xmlunit.version>
 
 		<version.eclipselink>2.1.2</version.eclipselink>
-		<version.javax.persistence>2.0.3</version.javax.persistence>
+		<version.javax.persistence>2.0.5</version.javax.persistence>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Update javax.persistence to version _2.0.5_ which is available in [central maven repository](http://search.maven.org/#artifactdetails%7Corg.eclipse.persistence%7Cjavax.persistence%7C2.0.5%7Cjar).
