### PR TITLE
Missing dependency 'com.sap.core.js.catalina.fragment' + using cargo for dev

### DIFF
--- a/odata-web/pom.xml
+++ b/odata-web/pom.xml
@@ -73,18 +73,23 @@
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>1.7.1</version>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.core.js.catalina</groupId>
-			<artifactId>com.sap.core.js.catalina.fragment</artifactId>
-			<version>1.1.1</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.tomcat</groupId>
-			<artifactId>tomcat-catalina</artifactId>
-			<version>7.0.30</version>
-			<scope>provided</scope>
-		</dependency>
 	</dependencies>
 
+    <profiles>
+      <profile>
+        <id>dev</id>
+        
+        <build>
+          <defaultGoal>cargo:run</defaultGoal>         
+          
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <version>1.4.2</version>
+            </plugin>
+          </plugins>
+        </build>        
+      </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
I have found that the following dependency could not be resolved:

```
-    <dependency>
-      <groupId>com.sap.core.js.catalina</groupId>
-      <artifactId>com.sap.core.js.catalina.fragment</artifactId>
-      <version>1.1.1</version>
-      <scope>provided</scope>
-    </dependency>
```

hence I have removed this and following Tomcat dependency.

Moreover, I have added a `dev` profile so that the ref implementation can be started via command-line as

```
$ mvn -Pdev
```
