### PR TITLE
Fixing Maven warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,11 @@
 					<artifactId>maven-bundle-plugin</artifactId>
 					<version>2.3.7</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>2.7</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 


### PR DESCRIPTION
Maven complains about missing version of the `maven-deploy-plugin`.
